### PR TITLE
Xml edits and DLL rollback

### DIFF
--- a/Data/Config/entityclasses.xml
+++ b/Data/Config/entityclasses.xml
@@ -732,9 +732,9 @@
 		<drop event="Harvest" name="animalHide" count="2" />
 		<drop event="Harvest" name="BrainMatter" count="2" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="5" prob=".5" />
-		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="6" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="4" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="1" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="1" />
@@ -742,14 +742,14 @@
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="5" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="4" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="1" prob=".75" />
 		<drop event="Harvest" name="Hoof" tool_category="Hunter" count="2" prob=".4" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
 		<!--JZMOD Butcher-->
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="2" prob=".5" />
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="8" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
@@ -764,7 +764,7 @@
 		<drop event="Harvest" name="Sinew" tool_category="Butcher" count="1" prob="1" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="9" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="4" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
@@ -836,9 +836,9 @@
 		<drop event="Harvest" name="animalHide" count="2" />
 		<drop event="Harvest" name="BrainMatter" count="2" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="5" prob=".5" />
-		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="8" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="3" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="3" prob=".5" />
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="5" />
@@ -846,7 +846,7 @@
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="11" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="8" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="2" prob=".65" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="2" prob=".55" />
 		<drop event="Harvest" name="BearFlank" tool_category="Hunter" count="1" prob=".2" />
@@ -854,7 +854,7 @@
 		<!--JZMOD Butcher-->
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="5" prob=".5" />
-		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="12" />
+		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="8" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="4" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="3" prob=".5" />
 		<drop event="Harvest" name="animalFat" tool_category="Butcher" count="6" />
@@ -981,15 +981,15 @@
 		<drop event="Harvest" name="animalHide" count="1" />
 		<drop event="Harvest" name="BrainMatter" count="1" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="1" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
         <drop event="Harvest" name="Sinew" tool_category="Hunter" count="2" prob=".65" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" />
 		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="2" />
 		<!--JZMOD Butcher-->
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="2" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="2" prob=".5" />
         <drop event="Harvest" name="Sinew" tool_category="Butcher" count="1" prob="1" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="1" prob=".5" />
@@ -1016,21 +1016,21 @@
 		<!-- JZMOD Harvest For Beginner -->
         <drop event="Harvest" name="trophyChicken" count="1" />
 		<drop event="Harvest" name="rawMeat" count="2" />
-		<drop event="Harvest" name="feather" count="5" />
+		<drop event="Harvest" name="feather" count="6" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="feather" tool_category="Hunter" count="10" />
-		<drop event="Harvest" name="feather" tool_category="Hunter" count="4" prob=".5" />
-		<drop event="Harvest" name="feather" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="1" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="feather" tool_category="Hunter" count="8" />
+		<drop event="Harvest" name="feather" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="feather" tool_category="Hunter" count="2" prob=".5" />
 		<!--JZMOD Butcher-->
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" />
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
-		<drop event="Harvest" name="feather" tool_category="Butcher" count="15" />
-		<drop event="Harvest" name="feather" tool_category="Butcher" count="5" prob=".5" />
-		<drop event="Harvest" name="feather" tool_category="Butcher" count="5" prob=".5" />
+		<drop event="Harvest" name="feather" tool_category="Butcher" count="12" />
+		<drop event="Harvest" name="feather" tool_category="Butcher" count="3" prob=".5" />
+		<drop event="Harvest" name="feather" tool_category="Butcher" count="3" prob=".5" />
 		<!--JZMOD Destroy-->
 		<drop event="Destroy" name="feather" count="1" />
 		<drop event="Destroy" name="feather" tool_category="Hunter" count="2" />
@@ -1053,8 +1053,8 @@
 		<drop event="Harvest" name="animalHide" count="2" />
 		<drop event="Harvest" name="BrainMatter" count="2" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
@@ -1063,14 +1063,14 @@
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="10" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="6" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="2" prob=".65" />
 		<drop event="Harvest" name="Hoof" tool_category="Hunter" count="2" prob=".4" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Hunter" count="1" prob=".2" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Hunter" count="1" prob=".2" />
 		<!--JZMOD Butcher-->
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
@@ -1083,7 +1083,7 @@
 		<drop event="Harvest" name="Sinew" tool_category="Butcher" count="2" prob="1" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="10" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="8" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Butcher" count="2" />
 		<!--JZMOD Destroy-->
 		<drop event="Destroy" name="femur" count="2" />
@@ -1796,13 +1796,13 @@
         <property name="AITarget-4" value="BlockingTargetTask" />
         <!-- JZMOD Harvest For Beginner -->
         <drop event="Harvest" name="trophyBuck" count="1" />
-		<drop event="Harvest" name="rawMeat" count="5" />
+     	<drop event="Harvest" name="rawMeat" count="5" />
 		<drop event="Harvest" name="animalHide" count="2" />
 		<drop event="Harvest" name="BrainMatter" count="2" />
-        <!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="3" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="5" prob=".5" />
-		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="6" />
+		<!--JZMOD Hunter-->
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="4" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="1" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="1" />
@@ -1810,14 +1810,14 @@
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="5" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="4" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="1" prob=".75" />
 		<drop event="Harvest" name="Hoof" tool_category="Hunter" count="2" prob=".4" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
 		<!--JZMOD Butcher-->
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="2" prob=".5" />
 		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="8" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
@@ -1832,7 +1832,7 @@
 		<drop event="Harvest" name="Sinew" tool_category="Butcher" count="1" prob="1" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="9" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="4" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
 		<drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
@@ -1869,8 +1869,8 @@
 		<drop event="Harvest" name="animalHide" count="2" />
 		<drop event="Harvest" name="BrainMatter" count="2" />
 		<!--JZMOD Hunter-->
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Hunter" count="2" prob=".5" />
@@ -1879,14 +1879,14 @@
 		<drop event="Harvest" name="animalFat" tool_category="Hunter" count="2" prob=".5" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
 		<drop event="Harvest" name="femur" tool_category="Hunter" count="1" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="10" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Hunter" count="6" />
 		<drop event="Harvest" name="Sinew" tool_category="Hunter" count="2" prob=".65" />
 		<drop event="Harvest" name="Hoof" tool_category="Hunter" count="2" prob=".4" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Hunter" count="1" prob=".2" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Hunter" count="1" prob=".2" />
 		<!--JZMOD Butcher-->
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
-		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="4" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
+		<drop event="Harvest" name="rawMeat" tool_category="Butcher" count="3" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
 		<drop event="Harvest" name="animalHide" tool_category="Butcher" count="2" prob=".5" />
@@ -1899,7 +1899,7 @@
 		<drop event="Harvest" name="Sinew" tool_category="Butcher" count="2" prob="1" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
 		<drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
-		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="10" />
+		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="8" />
 		<drop event="Harvest" name="PorkBelly" tool_category="Butcher" count="2" />
 		<!--JZMOD Destroy-->
 		<drop event="Destroy" name="femur" count="2" />

--- a/Data/Config/items.xml
+++ b/Data/Config/items.xml
@@ -11708,6 +11708,7 @@ Mesh files no longer used:
 			<property name="Buff" value="bleeding,criticalBlunt" />
 			<property name="Buff_chance" value=".4,.4" />
             <property name="ToolCategory.Butcher" value="1" />
+			<property name="ToolCategory.Hunter" value="0" />
 			<property name="Sound_harvesting" value="UseActions/open_animal" />
 			<property name="ActionExp" value="5" />
 			<property name="ActionExpBonusMultiplier" value="1" />

--- a/Data/Config/recipes.xml
+++ b/Data/Config/recipes.xml
@@ -2458,7 +2458,7 @@ Unfortunately auto-calc only seems to work on the first (top) ingredient in the 
 		<ingredient name="NutAndBolt" count="8" />
         <ingredient name="padlock" count="1" />
 	</recipe>
-	<recipe name="cntUSRBeerCooler" count="1" craft_area="workworkBench" craft_tool="clawHammer" craft_time="30" craft_exp_gain="25">
+	<recipe name="cntUSRBeerCooler" count="1" craft_area="workworkbench" craft_tool="clawHammer" craft_time="30" craft_exp_gain="25">
 		<ingredient name="scrapPlastics" count="20" />
 		<ingredient name="spring" count="2" />
 		<ingredient name="mechanicalParts" count="3" />
@@ -2477,7 +2477,7 @@ Unfortunately auto-calc only seems to work on the first (top) ingredient in the 
 		<ingredient name="nail" count="10" />
         <ingredient name="padlock" count="1" />
 	</recipe>
-	<recipe name="cntUSRCoffin" count="1" craft_area="workworkBench" craft_tool="clawHammer" craft_time="30" craft_exp_gain="25">
+	<recipe name="cntUSRCoffin" count="1" craft_area="workworkbench" craft_tool="clawHammer" craft_time="30" craft_exp_gain="25">
 		<ingredient name="Plank" count="30" />
 		<ingredient name="nail" count="10" />
 		<ingredient name="spring" count="2" />


### PR DESCRIPTION
Removed duplicate tool_category on fieldKnife which was doubling animal
drops
Lowered rawmeat and brain matter drops on all animals
Fixed User created coffin and cooler recipes
Rolled back Assembly-CSharp.DLL to the 4/10 version.  This removes the
fix that eliminated the need to use the taskmanager on exiting from the
server.  Also eliminates some other unused features installed for
version A16.  Retained the punchback, anti-nerdpole, zero damage by
weaker materials on stronger, and crafting lag fixes.  Tested stable on
various old saves on SP and against server saves.  Loads "corrupted
saves and may recover them.